### PR TITLE
Increase version_max to 8.0 for the PCM

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -21,7 +21,7 @@
             "version": "1.1",
             "status": "stable",
             "kicad_version": "6.0",
-            "kicad_version_max": "7.0"
+            "kicad_version_max": "8.0"
         }
     ]
 }

--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -21,7 +21,7 @@
             "version": "1.1",
             "status": "stable",
             "kicad_version": "6.0",
-            "kicad_version_max": "8.0"
+            "kicad_version_max": "8.99"
         }
     ]
 }


### PR DESCRIPTION
Fix issue described in #13, which is preventing it from being downloaded via the KiCAD PCM.

Also fixes issue #12 